### PR TITLE
fix/ruby_version_with_symbols

### DIFF
--- a/lib/belugas/ruby/parser/gemfile.rb
+++ b/lib/belugas/ruby/parser/gemfile.rb
@@ -29,10 +29,20 @@ module Belugas
         end
 
         def ruby_version
-          ENV['FALLBACK_RUBY_VERSION'] || content.scan(/ruby ["'](.*?)["']/).flatten[0] || FALLBACK_RUBY_VERSION
+          ENV['FALLBACK_RUBY_VERSION'] || remove_symbols_from_ruby_version(content.scan(/ruby ["'](.*?)["']/).flatten[0]) || FALLBACK_RUBY_VERSION
         end
 
         private
+
+        def remove_symbols_from_ruby_version(ruby_version)
+          return nil if ruby_version.nil?
+
+          ruby_version.delete!("<")
+          ruby_version.delete!(">")
+          ruby_version.delete!("=")
+          ruby_version.delete!(' ')
+          ruby_version
+        end
 
         def runtime_groups
           @runtime_groups ||= [:default, :production]

--- a/lib/belugas/ruby/parser/gemfile.rb
+++ b/lib/belugas/ruby/parser/gemfile.rb
@@ -37,11 +37,7 @@ module Belugas
         def remove_symbols_from_ruby_version(ruby_version)
           return nil if ruby_version.nil?
 
-          ruby_version.delete!("<")
-          ruby_version.delete!(">")
-          ruby_version.delete!("=")
-          ruby_version.delete!(' ')
-          ruby_version
+          (ruby_version.match Patterns::DIGITS_REGEX)[0].to_s
         end
 
         def runtime_groups

--- a/lib/belugas/ruby/parser/patterns.rb
+++ b/lib/belugas/ruby/parser/patterns.rb
@@ -37,6 +37,7 @@ module Belugas
         ADD_DEPENDENCY_CALL = /^[ \t]*\w+\.add(?<type>_runtime|_development)?_dependency\(?[ \t]*#{QUOTED_GEM_NAME}(?:[ \t]*,[ \t]*#{REQUIREMENTS})?[ \t]*\)?[ \t]*#{COMMENT}$/
 
         GEM_VERSION = /[^~><=>==><](\d*?)[^~><=>==><]*/
+        DIGITS_REGEX = /(\d+([,.]\d)+)/
 
         def self.options(string)
           {}.tap do |hash|

--- a/spec/belugas/ruby/dispatcher_spec.rb
+++ b/spec/belugas/ruby/dispatcher_spec.rb
@@ -117,4 +117,16 @@ describe Belugas::Ruby::Dispatcher do
                                                           "engines" => ["belugas", "belugas-ruby"] }])
     end
   end
+
+  context "with ruby version with symbols (>,=>,<,=<)" do
+    it "return version without symbols" do
+      ruby_version_with_symbols = Belugas::Ruby::Dispatcher.new("spec/support/ruby_version_with_symbols_Gemfile")
+      expect(ruby_version_with_symbols.render).to eq([{ "type" => "feature",
+                                                          "name" => "Ruby",
+                                                          "version" => "2.3.1",
+                                                          "description" => "The application uses Ruby code",
+                                                          "categories" => ["Language"],
+                                                          "engines" => ["belugas", "belugas-ruby"] }])
+    end
+  end
 end

--- a/spec/support/ruby_version_with_symbols_Gemfile
+++ b/spec/support/ruby_version_with_symbols_Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+ruby '>= 2.3.1'


### PR DESCRIPTION
### What does this PR do?
* Deletes symbols like (<,>,=) in ruby version